### PR TITLE
Changed python-publish.yml to enable publishing to PyPI by GitHub Act…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+      id-token: write
 
 jobs:
   deploy:
@@ -34,6 +34,3 @@ jobs:
       run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Changed python-publish.yml to enable publishing to PyPI by GitHub Action because the original version that GitHub offers is designed for publishing by token, which is no longer recommended by PyPI.