### PR TITLE
Removed (v2) from license classifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Phil Gold", email = "phil_g@pobox.com" },
            { name = "Ethan Strominger", email = "ethanstrominger2@gmail.com" }]
 license = { file = "LICENSE" }
 classifiers = [
-    "License :: OSI Approved :: Apache Software License (v2)",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
PyPI does not like the (v2) after Apache Software License in the license classifier of pyproject.toml.