### PR TITLE
Updated the README to link to the Home Energy Analysis Tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ standard, mostly figured out from public sources and actual ESPI files.
 Forked from the original repository [greenbutton-objects](https://github.com/asciipip/greenbutton-python)
 and packaged to be published on PyPI.
 
+Used by the Code for Boston [Home Energy Analysis Tool](https://github.com/codeforboston/home-energy-analysis-tool).
+
 
 ## Development
 Simple steps for development setup:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "greenbutton_objects"
-version = "2024.6.25"
+version = "2024.7.3"
 description = "Parse Green Button XML files into Python objects."
 readme = "README.md"
 authors = [{ name = "Phil Gold", email = "phil_g@pobox.com" },


### PR DESCRIPTION
This pull request links the README of this repository to the [Home Energy Analysis Tool](https://github.com/codeforboston/home-energy-analysis-tool).