### PR TITLE
Small fix to Python workflow GHA trigger

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,9 @@
 name: python
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: [ master ]
 
 
 jobs:


### PR DESCRIPTION
Looks like python test workflows don't run on PR opening